### PR TITLE
Align with sql like readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,29 @@ This lab is primarily test-driven. So run the test suite with the `learn` comman
 
 ### Building the has many/belongs to relationship
 
+#### Artists and Songs
 How can an artist have many songs and a song belong to an artist? 
 
 An individual song will need to be able to be initialized with an `artist` object -- which can be passed in as an argument to the Song.new method -- and should have an `#artist` getter method to reveal the artist. The Song class itself should have a class variable `@@all` equal to an array which will contain each created Song, the songs should be added to that array when they are created. It should be able to reveal that array of songs with an `.all` class method.
 
-An individual artist will need to have a `#songs` method that will run a `select` iteration on the return value of the Song classes `all` method (The array of songs contained in its `@@all` array), and select the songs whose artist is equal to `self`.
+An individual artist will need to have a `#songs` method that will run a `select` iteration on the return value of the Song class' `all` method (the array of songs contained in its `@@all` class variable), and select the songs whose artist is equal to `self`.
+
+
+#### Authors and Posts
 
 How can an author have many posts and a post belong to an author? Well by using the same exact logic we used for our Song and Artist classes! The Post class will keep track of all created posts in an `@@all` class variable, exposed by it's `all` getter method. And each instance of post will hold on to it's author. An author will be able to find it's posts by calling the Post classes `all` method, and running a `select` iteration on that array to capture each post with an author equal to self.
 
-#### The `#add_song_by_name` and `#add_post_by_title` Methods
+### Building on our Associations
 
-To get the tests on these methods passing, you'll need to define methods that take in an argument of a name (or title), and use that argument to create a new song (or post) passing in `self` as the artist (or author) which will associate the objects to each other. 
+Now that we have our classes and associations successfuly set up, we can focus on building some cool methods that utilize our associations to add some convenient functionality:
 
-#### The `#artist_name` and `#author_name` Methods
+#### The `Song#add_song_by_name` and `Post#add_post_by_title` Methods
 
-Build the methods `some_song.artist_name` and `some_post.author_name` that return the names of the artist and author of the given song and post respectively.
+To get the tests on these methods passing, you'll need to define methods that accept an argument of a name (or title), and use that argument to create a new song (or post) passing in `self` as the artist (or author) which will create that new instance and associate the objects to each other.
+
+#### The `Song#artist_name` and `Post#author_name` Methods
+
+Build these methods to return the names of the artist and author of the given song and post respectively.
 
 These methods should use, or extend, the has many/belongs to relationship you're building out. If a song has an artist, you can call: `some_song.artist` and return an actual instance of the `Artist` class. Since every artist has a name, `some_song.artist.name` should return the name of a the `Artist` instance associated with the given song. Your `#artist_name` method should utilize this relationship. 
 

--- a/README.md
+++ b/README.md
@@ -13,21 +13,23 @@ In this lab, we'll be dealing with two sets of classes. The `Artist` and `Song` 
 
 Because of the has many/belongs to relationship between your classes, the `Artist` tests, i.e. the tests in `spec/artist_spec.rb`, rely on some code in the `Song` class and vice versa. The same is true of the tests for the `Author` and `Post` classes. So, as you proceed through solving this lab, you will go back and forth between coding in `Artist` and `Song` and between coding in `Author` and `Post`. 
 
-We recommend starting out by getting some of the initial `Artist` tests passing and switching to write code in the `Song` class as directed by the test output. Then, once your `Artist` and `Song` tests are passing, do the same for `Author` and `Post`. 
+We recommend starting out by getting some of the initial `Song` tests passing and switching to write code in the `Artist` class as directed by the test output. Then, once your `Artist` and `Song` tests are passing, do the same for `Author` and `Post`. 
 
 This lab is primarily test-driven. So run the test suite with the `learn` command to get started. Read the test output very carefully to help guide you through. First, read through the guidelines below and refer back to them as you complete the lab. 
 
 ### Building the has many/belongs to relationship
 
-How can an artist have many songs and a song belong to an artist? An individual song will need to have an `artist=()` and `artist` method and an individual artist will need to be initialized with an empty collection of songs. 
+How can an artist have many songs and a song belong to an artist? 
 
-How can an author have many posts and a post belong to an author? An individual post will need to have an `author=()` and `author` method and an individual author will need to be initialized with an empty collection of posts.
+An individual song will need to be able to be initialized with an `artist` object -- which can be passed in as an argument to the Song.new method -- and should have an `#artist` getter method to reveal the artist. The Song class itself should have a class variable `@@all` equal to an array which will contain each created Song, the songs should be added to that array when they are created. It should be able to reveal that array of songs with an `.all` class method.
+
+An individual artist will need to have a `#songs` method that will run a `select` iteration on the return value of the Song classes `all` method (The array of songs contained in its `@@all` array), and select the songs whose artist is equal to `self`.
+
+How can an author have many posts and a post belong to an author? Well by using the same exact logic we used for our Song and Artist classes! The Post class will keep track of all created posts in an `@@all` class variable, exposed by it's `all` getter method. And each instance of post will hold on to it's author. An author will be able to find it's posts by calling the Post classes `all` method, and running a `select` iteration on that array to capture each post with an author equal to self.
 
 #### The `#add_song_by_name` and `#add_post_by_title` Methods
 
-To get the tests on these methods passing, you'll need to define methods that take in an argument of a name (or title), use that argument to create a new song (or post) and *then* associate the objects. 
-
-For `add_post_by_title`, you'll want to make sure the body of the method associates the newly created post with an author and adds the post to the author's collection.
+To get the tests on these methods passing, you'll need to define methods that take in an argument of a name (or title), and use that argument to create a new song (or post) passing in `self` as the artist (or author) which will associate the objects to each other. 
 
 #### The `#artist_name` and `#author_name` Methods
 
@@ -35,12 +37,7 @@ Build the methods `some_song.artist_name` and `some_post.author_name` that retur
 
 These methods should use, or extend, the has many/belongs to relationship you're building out. If a song has an artist, you can call: `some_song.artist` and return an actual instance of the `Artist` class. Since every artist has a name, `some_song.artist.name` should return the name of a the `Artist` instance associated with the given song. Your `#artist_name` method should utilize this relationship. 
 
-**Note:** We like our code to be robust, i.e. not easily breakable. Make sure your `#artist_name` and `#author_name` methods will not break if the given song or post does not have an artist or author. In this case, your methods should return `nil`.  
+**Note:** We like our code to be robust, i.e. not easily breakable. Make sure your `#artist_name` and `#author_name` methods will not break if the given song or post does not have an artist or author. In this case, your methods should return `nil`. (Think about how you'd prevent the code from breaking in a cese where we create a song or post without passing in the artist or author argument)
 
-### The `.song_count` and `.post_count` Methods
-
-You'll be required to write a class method that tracks the total number of songs, tallied up from all of the existing artists. You'll be required to write a similar method for the `Author` class. 
-
-How do we keep track of data regarding an entire class? With class variables! The `Artist` class should have a class variable, `@@song_count`. This variable should start out set equal to `0`. When should you increment this value? Anytime a new song is added to an artist. Your `.song_count` method should then return the value of the `@@song_count` variable. Build out the same logic for your `Author` class. 
 
 <p data-visibility='hidden'>View <a href='https://learn.co/lessons/ruby-objects-has-many-lab' title='Ruby Objects Has Many Lab'>Ruby Objects Has Many Lab</a> on Learn.co and start learning to code for free.</p>

--- a/spec/artist_spec.rb
+++ b/spec/artist_spec.rb
@@ -3,53 +3,39 @@ require "spec_helper"
 describe "Artist" do
 
   let!(:adele) { Artist.new("Adele") } 
+  let!(:hello) { Song.new("Hello", adele)}
 
-    describe "#new" do 
-      it "is initialized with a name" do 
-        expect{Artist.new("Beyonce")}.to_not raise_error
-      end
+  describe "#new" do 
+    it "is initialized with a name" do 
+      expect{Artist.new("Beyonce")}.to_not raise_error
+    end
+  end
 
-      it "is initialized with an empty collection of songs" do 
-        expect(adele.instance_variable_get(:@songs)).to match([])
-      end
+  describe "#name" do
+    it "has an attr_accessor for name" do 
+      expect(adele.name).to eq("Adele")
+    end
+  end
+
+  describe "#songs" do 
+    it "selects the songs from the Song class which have `self` as the artist" do
+      expect(adele.songs).to be_a(Array)
+      expect(adele.songs).to include(hello)
     end
 
-    describe "#name" do
-      it "has an attr_accessor for name" do 
-        expect(adele.name).to eq("Adele")
+    it "does not select the songs which don't 'belong' to itself" do
+      nintynine_problems = Song.new("Ninty Nine Problems")
+      expect(adele.songs).to be_a(Array)
+      expect(adele.songs).to include(hello)
+      expect(adele.songs).to_not include(nintynine_problems)
     end
+  end
 
-    describe "#songs" do 
-      it "has many songs" do
-        expect(adele.songs).to be_a(Array)
-      end
-    end
-
-    describe "#add_song" do 
-      it "takes in an argument of a song and adds that song to the artist's collection and tells the song that it belongs to that artist" do 
-        hello = Song.new("Hello")
-        adele.add_song(hello)
-        expect(adele.songs).to include(hello)
-        expect(hello.artist).to eq(adele)
-      end
-    end
-
-    describe "#add_song_by_name" do 
-      it "takes in an argument of a song name, creates a new song with it and associates the song and artist" do 
-        adele.add_song_by_name("Rolling in the Deep")
-        expect(adele.songs.last.name).to eq("Rolling in the Deep")
-        expect(adele.songs.last.artist).to eq(adele)
-      end
-    end
-
-    describe ".song_count" do 
-      it "is a class method that returns the total number of songs associated to all existing artists" do 
-        expect(Artist.song_count).to eq(2)
-      end
-
-      it "uses the class variable, @@song_count" do 
-        expect(Artist.class_variable_get(:@@song_count)).to be_a(Integer)
-      end
+  describe "#add_song_by_name" do 
+    it "takes in an argument of a song name, creates a new song with it and associates the song and artist" do 
+      adele.add_song_by_name("Rolling in the Deep")
+      expect(adele.songs.last.name).to eq("Rolling in the Deep")
+      expect(adele.songs.last.artist).to eq(adele)
     end
   end
 end

--- a/spec/author_spec.rb
+++ b/spec/author_spec.rb
@@ -1,58 +1,42 @@
 require "spec_helper"
-require 'pry'
 
 describe "Author" do
 
   let!(:betty) { Author.new("Betty") } 
+  let!(:post) { Post.new("I love to program while drinking chamomile tea!", betty) } 
 
-    describe "#new" do 
-      it "is initialized with a name" do 
-        expect{Author.new("Betty")}.to_not raise_error
-      end
+  describe "#new" do 
+    it "is initialized with a name" do 
+      expect{Author.new("Betty")}.to_not raise_error
+    end
+  end
 
-      it "is initialized with an empty collection of posts" do 
-        expect(betty.instance_variable_get(:@posts)).to match([])
-      end
+  describe "#name" do
+    it "has an attr_accessor for name" do 
+      expect(betty.name).to eq("Betty")
+    end
+  end
+
+  describe "#posts" do 
+    it "selects the posts from the Post class which have `self` as the author" do
+      expect(betty.posts).to be_a(Array)
+      expect(betty.posts).to include(post)
     end
 
-    describe "#name" do
-      it "has an attr_accessor for name" do 
-        expect(betty.name).to eq("Betty")
+    it "does not select the posts which don't 'belong' to itself" do
+      no_author = Post.new("I feel like I made myself!")
+      betty_posts = betty.posts
+      expect(betty_posts).to be_a(Array)
+      expect(betty_posts).to include(post)
+      expect(betty_posts).to_not include(no_author)
     end
+  end
 
-    describe "#posts" do 
-      it "has many posts" do
-        expect(betty.posts).to be_a(Array)
-      end
-    end
-
-    describe "#add_post" do 
-      it "takes in an argument of a post and adds that post to the author's collection and tells the post that it belongs to that author" do 
-        hello_world = Post.new("Hello World")
-        betty.add_post(hello_world)
-        expect(betty.posts).to include(hello_world)
-        expect(hello_world.author).to eq(betty)
-      end
-    end
-
-    describe "#add_post_by_title" do 
-      it "takes in an argument of a post title, creates a new post with it and associates the post and author" do 
-        betty.add_post_by_title("My Great Blog Post")
-        # binding.pry
-        expect(betty.posts.last.title).to eq("My Great Blog Post")
-        expect(betty.posts.last.author).to eq(betty)
-      end
-    end
-
-    describe ".post_count" do 
-      it "is a class method that returns the total number of posts associated to all existing authors" do 
-        # binding.pry
-        expect(Author.post_count).to eq(2)
-      end
-
-      it "uses the class variable, @@post_count" do 
-        expect(Author.class_variable_get(:@@post_count)).to be_a(Integer)
-      end
+  describe "#add_post_by_title" do 
+    it "takes in an argument of a post title, creates a new post with it and associates the post and author" do 
+      betty.add_post_by_title("My Great Blog Post")
+      expect(betty.posts.last.title).to eq("My Great Blog Post")
+      expect(betty.posts.last.author).to eq(betty)
     end
   end
 end

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -2,10 +2,32 @@ require "spec_helper"
 
 describe "Post" do 
 
-  let!(:post){Post.new("My Blog Post!")}
+  let!(:author) { Author.new("Sophie") } 
+  let!(:post) {Post.new("My Blog Post!", author)}
+
+  describe 'Post' do
+    it "is has a class variable @@all" do
+      expect(Post.class_variable_get(:@@all)).to be_a(Array)
+    end
+
+    describe '.all' do
+      it "returns the @@all array" do
+        all = Post.class_variable_get(:@@all)
+        posts = Post.all
+        expect(posts).to be_a(Array)
+        expect(posts).to be(all)
+      end
+    end
+  end
+
   describe "#new" do 
-    it "is initialized with an argument of a title" do 
-      expect{Post.new("Hello World")}.to_not raise_error
+    it "is initialized with an argument of a title and an optional author object" do 
+      expect{Post.new("Hello World", author)}.to_not raise_error
+      expect{Post.new("Hi Again World")}.to_not raise_error, 'The author argument should be optional!'
+    end
+
+    it "adds self to the @@all array" do
+      expect(Post.all).to include(post)
     end
   end
 
@@ -17,21 +39,18 @@ describe "Post" do
 
   describe "#author" do
     it "belongs to an author" do 
-      sophie = Author.new("Sophie")
-      post.author = sophie
-      expect(post.author).to eq(sophie)
+      expect(post.author).to eq(author)
     end 
   end
 
   describe "#author_name" do
     it "knows the name of it's author" do 
-      sophie = Author.new("Sophie")
-      post.author = sophie
       expect(post.author_name).to eq("Sophie")
     end 
 
     it "returns nil if the post does not have an author" do 
-      expect(post.author_name).to eq nil
+      no_author_post = Post.new("I feel kinda authorless!")
+      expect(no_author_post.author_name).to eq nil
     end
   end
 end

--- a/spec/song_spec.rb
+++ b/spec/song_spec.rb
@@ -2,12 +2,36 @@ require "spec_helper"
 
 describe "Song" do 
 
-  let!(:song) {Song.new("Survivor")}
-  describe "#new" do 
-    it "is initialized with an argument of a name" do 
-      expect{Song.new("Say my Name")}.to_not raise_error
+  let!(:artist) {Artist.new("Drake")}
+  let!(:song) {Song.new("Survivor", artist)}
+
+  # is this the right way to run class tests?
+  describe 'Song' do
+    it "is has a class variable @@all" do
+      expect(Song.class_variable_get(:@@all)).to be_a(Array)
+    end
+
+    describe '.all' do
+      it "returns the @@all array" do
+        all = Song.class_variable_get(:@@all)
+        songs = Song.all
+        expect(songs).to be_a(Array)
+        expect(songs).to be(all)
+      end
     end
   end
+
+  describe "#new" do 
+    it "is initialized with an argument of a name and an optional artist object" do 
+      expect{Song.new("Say my Name", artist)}.to_not raise_error
+      expect{Song.new("I have no Artist")}.to_not raise_error, 'The artist argument should be optional!'
+    end
+
+    it "adds self to the @@all array" do
+      expect(Song.all).to include(song)
+    end
+  end
+
 
   describe "#name" do 
     it "has a name" do
@@ -17,16 +41,12 @@ describe "Song" do
 
   describe "#artist" do
     it "belongs to an artist" do 
-      drake = Artist.new("Drake")
-      song.artist = drake
-      expect(song.artist).to eq(drake)
+      expect(song.artist).to eq(artist)
     end 
   end
 
   describe "#artist_name" do
     it "knows the name of it's artist" do 
-      drake = Artist.new("Drake")
-      song.artist = drake
       expect(song.artist_name).to eq("Drake")
     end 
 


### PR DESCRIPTION
In the Readme lesson for this Lab we have changed our has_many approach to be more aligned with the way sql does it and less redundant.
Now an Artist will have_many songs through a songs method that selects all songs with an artist equal to self for the Songs classes all array - a list of all created songs.

The readme and specs have been changed to reflect this.
- Removed the tests for artist class to count the songs. Previously an artist instance was tasked with keeping track of all its own songs so an overall class counter may have made more sense. Now these concerns are separated and such a counter is irrelevant.
- Removed the add_song method from the artist. Same idea here, the artist is associated with the song by being assigned to it, or passed in as an argument on creation. there is no need for it to take a song and assign self as the song artist when we can merely write `song.artist = artist`.

All of the above applies to the Author Post relationship in this lab.

This is relevant to [this issue](https://github.com/learn-co-curriculum/ruby-objects-has-many-readme/issues/30) and [this pull request](https://github.com/learn-co-curriculum/ruby-objects-has-many-readme/pull/31)

NOTE: Not to be merged until the entire section had been modified to align with this approach

I would love feedback/criticism/a-sound-thrashing-cuz-i-messed-this-up on this.

**cc**: @pletcher @AnnJohn @aturkewi @PeterBell 
